### PR TITLE
Clean up unit tests slightly

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,6 +1,5 @@
 //! This module deals with handles to connected devices.
 
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 /// Handle for a connected device.
@@ -15,13 +14,6 @@ pub struct Device {
 impl From<PathBuf> for Device {
     fn from(sysfs_path: PathBuf) -> Self {
         Self { sysfs_path }
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl Hash for Device {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.sysfs_path.hash(state);
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -37,3 +37,104 @@ impl Device {
         others.filter(move |device| device.sysfs_path.starts_with(&self.sysfs_path))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use crate::testing;
+
+    use super::*;
+
+    /// Check that asking for devices' parents does not error.
+    #[test]
+    fn parents() {
+        let devices: Vec<Device> = testing::mock_dev_paths().map(Into::into).collect();
+
+        // Collect each device's parent into a `BTreeSet` by only its `sysfs_path`.
+        // The set allows us to compare without worrying about the order of discovery.
+        let parents: BTreeSet<_> = devices
+            .iter()
+            .map(|dev| {
+                let parent = dev.parent(&devices).map(|parent| parent.sysfs_path.clone());
+                (dev.sysfs_path.clone(), parent)
+            })
+            .collect();
+
+        // These are the expected parents for each device by its path relative to
+        // `/sys/devices/`.
+        let expected_parents: BTreeSet<_> = [
+            ("device_0", None),
+            ("device_1", None),
+            ("device_1/device_2", Some("device_1")),
+            ("device_1/device_2/device_3", Some("device_1/device_2")),
+            ("device_1/device_2/device_4", Some("device_1/device_2")),
+            ("device_5", None),
+            ("device_6", None),
+            ("device_7", None),
+        ]
+        .into_iter()
+        .map(|(path, parent)| {
+            (
+                testing::prefix_dev_path(path),
+                parent.map(testing::prefix_dev_path),
+            )
+        })
+        .collect();
+
+        assert_eq!(parents, expected_parents);
+    }
+
+    /// Check that asking for devices' descendants does not error.
+    #[test]
+    fn descendants() {
+        let devices: Vec<Device> = testing::mock_dev_paths().map(Into::into).collect();
+
+        // Collect each device's descendants into a `BTreeSet` by only its `sysfs_path`.
+        // The set allows us to compare without worrying about the order of discovery.
+        let descendants: BTreeSet<_> = devices
+            .iter()
+            .map(|dev| {
+                let descendants = dev
+                    .descendants(&devices)
+                    .map(|descendant| descendant.sysfs_path.clone())
+                    .collect::<BTreeSet<_>>();
+                (dev.sysfs_path.clone(), descendants)
+            })
+            .collect();
+
+        // These are the expected descendants for each device by their paths relative to
+        // `/sys/devices/`.
+        let expected_descendants: BTreeSet<_> = [
+            ("device_0", vec![]),
+            (
+                "device_1",
+                vec![
+                    "device_1/device_2",
+                    "device_1/device_2/device_3",
+                    "device_1/device_2/device_4",
+                ],
+            ),
+            (
+                "device_1/device_2",
+                vec!["device_1/device_2/device_3", "device_1/device_2/device_4"],
+            ),
+            ("device_1/device_2/device_3", vec![]),
+            ("device_1/device_2/device_4", vec![]),
+            ("device_5", vec![]),
+            ("device_6", vec![]),
+            ("device_7", vec![]),
+        ]
+        .into_iter()
+        .map(|(path, descendants)| {
+            let descendants = descendants
+                .into_iter()
+                .map(testing::prefix_dev_path)
+                .collect::<BTreeSet<_>>();
+            (testing::prefix_dev_path(path), descendants)
+        })
+        .collect();
+
+        assert_eq!(descendants, expected_descendants);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,23 @@
 pub(crate) mod device;
 pub(crate) mod scan;
 
+#[cfg(test)]
+pub(crate) mod testing;
+
 use std::io;
 
 #[doc(inline)]
 pub use device::Device;
+
+/// Path to Linux sysfs directory.
+///
+/// The path is changed for tests so we get consistent results regardless of
+/// where the tests are run.
+pub(crate) const SYSFS_PATH: &str = if cfg!(test) {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/sys")
+} else {
+    "/sys"
+};
 
 /// Scan the Linux sysfs for devices.
 pub fn scan() -> io::Result<Vec<Device>> {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -10,12 +10,6 @@ use std::path::PathBuf;
 
 use crate::Device;
 
-const SYSFS_PATH: &str = if cfg!(test) {
-    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/sys")
-} else {
-    "/sys"
-};
-
 /// Connected device scanner.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Scanner {
@@ -32,18 +26,14 @@ impl Scanner {
         scanner.scan_class()?;
         scanner.scan_block()?;
 
-        let devices = scanner
-            .device_paths
-            .into_iter()
-            .map(|path| path.into())
-            .collect();
+        let devices = scanner.device_paths.into_iter().map(Into::into).collect();
 
         Ok(devices)
     }
 
     /// Scan the `/sys/bus/` directory for devices and print their sysfs paths.
     fn scan_bus(&mut self) -> io::Result<()> {
-        let path: PathBuf = [SYSFS_PATH, "bus"].iter().collect();
+        let path: PathBuf = [crate::SYSFS_PATH, "bus"].iter().collect();
 
         for subsys in fs::read_dir(path)? {
             let devices = subsys?.path().join("devices");
@@ -61,7 +51,7 @@ impl Scanner {
 
     /// Scan the `/sys/class/` directory for devices and print their sysfs paths.
     fn scan_class(&mut self) -> io::Result<()> {
-        let path: PathBuf = [SYSFS_PATH, "class"].iter().collect();
+        let path: PathBuf = [crate::SYSFS_PATH, "class"].iter().collect();
 
         for class in fs::read_dir(path)? {
             let devices = class?.path();
@@ -85,7 +75,7 @@ impl Scanner {
 
     /// Scan the `/sys/block/` directory for devices and print their sysfs paths.
     fn scan_block(&mut self) -> io::Result<()> {
-        let path: PathBuf = [SYSFS_PATH, "block"].iter().collect();
+        let path: PathBuf = [crate::SYSFS_PATH, "block"].iter().collect();
 
         for device in fs::read_dir(&path)? {
             let device_link = device?.path().read_link()?;
@@ -102,6 +92,8 @@ impl Scanner {
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::testing;
+
     use super::*;
 
     /// Check scanning does not error.
@@ -115,114 +107,8 @@ mod tests {
         // We use a `BTreeSet` so we don't have to worry about the order of discovery
         // when we compare them later.
         let device_paths: BTreeSet<_> = devices.into_iter().map(|dev| dev.sysfs_path).collect();
-
-        let root_path: PathBuf = [SYSFS_PATH, "devices"].iter().collect();
-        let expected_paths: BTreeSet<_> = [
-            "device_0",
-            "device_1",
-            "device_1/device_2",
-            "device_1/device_2/device_3",
-            "device_1/device_2/device_4",
-            "device_5",
-            "device_6",
-            "device_7",
-        ]
-        .into_iter()
-        .map(|path| root_path.join(path))
-        .collect();
+        let expected_paths: BTreeSet<_> = testing::mock_dev_paths().collect();
 
         assert_eq!(device_paths, expected_paths);
-    }
-
-    /// Check that asking for devices' parents does not error.
-    #[test]
-    fn parents() {
-        let devices = Scanner::scan().expect("failed to scan");
-
-        // Collect each device's parent into a `BTreeSet` by only its `sysfs_path`.
-        // The set allows us to compare without worrying about the order of discovery.
-        let parents: BTreeSet<_> = devices
-            .iter()
-            .map(|dev| {
-                let parent = dev.parent(&devices).map(|parent| parent.sysfs_path.clone());
-                (dev.sysfs_path.clone(), parent)
-            })
-            .collect();
-
-        // These are the expected parents for each device by its path relative to
-        // `/sys/devices/`.
-        let root_path: PathBuf = [SYSFS_PATH, "devices"].iter().collect();
-        let expected_parents: BTreeSet<_> = [
-            ("device_0", None),
-            ("device_1", None),
-            ("device_1/device_2", Some("device_1")),
-            ("device_1/device_2/device_3", Some("device_1/device_2")),
-            ("device_1/device_2/device_4", Some("device_1/device_2")),
-            ("device_5", None),
-            ("device_6", None),
-            ("device_7", None),
-        ]
-        .into_iter()
-        .map(|(path, parent)| {
-            let parent = parent.map(|parent| root_path.join(parent));
-            (root_path.join(path), parent)
-        })
-        .collect();
-
-        assert_eq!(parents, expected_parents);
-    }
-
-    /// Check that asking for devices' descendants does not error.
-    #[test]
-    fn descendants() {
-        let devices = Scanner::scan().expect("failed to scan");
-
-        // Collect each device's descendants into a `BTreeSet` by only its `sysfs_path`.
-        // The set allows us to compare without worrying about the order of discovery.
-        let descendants: BTreeSet<_> = devices
-            .iter()
-            .map(|dev| {
-                let descendants = dev
-                    .descendants(&devices)
-                    .map(|descendant| descendant.sysfs_path.clone())
-                    .collect::<BTreeSet<_>>();
-                (dev.sysfs_path.clone(), descendants)
-            })
-            .collect();
-
-        // These are the expected descendants for each device by their paths relative to
-        // `/sys/devices/`.
-        let root_path: PathBuf = [SYSFS_PATH, "devices"].iter().collect();
-        let expected_descendants: BTreeSet<_> = [
-            ("device_0", vec![]),
-            (
-                "device_1",
-                vec![
-                    "device_1/device_2",
-                    "device_1/device_2/device_3",
-                    "device_1/device_2/device_4",
-                ],
-            ),
-            (
-                "device_1/device_2",
-                vec!["device_1/device_2/device_3", "device_1/device_2/device_4"],
-            ),
-            ("device_1/device_2/device_3", vec![]),
-            ("device_1/device_2/device_4", vec![]),
-            ("device_5", vec![]),
-            ("device_6", vec![]),
-            ("device_7", vec![]),
-        ]
-        .into_iter()
-        .map(|(path, descendants)| {
-            let descendants = descendants
-                .into_iter()
-                .map(|descendant| root_path.join(descendant))
-                .collect::<BTreeSet<_>>();
-            (root_path.join(path), descendants)
-        })
-        .collect();
-
-        assert_eq!(descendants, expected_descendants);
     }
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -19,7 +19,8 @@ const SYSFS_PATH: &str = if cfg!(test) {
 /// Connected device scanner.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Scanner {
-    devices: HashSet<Device>,
+    /// Paths in `/sys/devices` discovered by the scanner.
+    device_paths: HashSet<PathBuf>,
 }
 
 impl Scanner {
@@ -31,7 +32,12 @@ impl Scanner {
         scanner.scan_class()?;
         scanner.scan_block()?;
 
-        let devices = scanner.devices.into_iter().collect();
+        let devices = scanner
+            .device_paths
+            .into_iter()
+            .map(|path| path.into())
+            .collect();
+
         Ok(devices)
     }
 
@@ -46,7 +52,7 @@ impl Scanner {
                 let device_link = device?.path().read_link()?;
                 let device_path = devices.join(device_link).canonicalize()?;
 
-                self.devices.insert(device_path.into());
+                self.device_paths.insert(device_path);
             }
         }
 
@@ -70,7 +76,7 @@ impl Scanner {
                 let device_link = device_path.read_link()?;
                 let device_path = devices.join(device_link).canonicalize()?;
 
-                self.devices.insert(device_path.into());
+                self.device_paths.insert(device_path);
             }
         }
 
@@ -85,7 +91,7 @@ impl Scanner {
             let device_link = device?.path().read_link()?;
             let device_path = path.join(device_link).canonicalize()?;
 
-            self.devices.insert(device_path.into());
+            self.device_paths.insert(device_path);
         }
 
         Ok(())

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,33 @@
+//! Module of internal test utilities.
+//!
+//! Only code used by multiple modules needs to go here.
+
+use std::path::PathBuf;
+
+/// Returns the list of device paths in the mock sysfs.
+///
+/// This list will be kept up to date with the mock directory in this repo,
+/// otherwise the `scan` tests will fail.
+///
+/// Unit tests should use this device list even if not getting their devices
+/// from a scan.
+pub fn mock_dev_paths() -> impl Iterator<Item = PathBuf> {
+    [
+        "device_0",
+        "device_1",
+        "device_1/device_2",
+        "device_1/device_2/device_3",
+        "device_1/device_2/device_4",
+        "device_5",
+        "device_6",
+        "device_7",
+    ]
+    .into_iter()
+    .map(prefix_dev_path)
+}
+
+/// Prefix a device path relative to `/sys/devices/` to give an absolute path.
+pub fn prefix_dev_path(dev_path: &str) -> PathBuf {
+    let root_path: PathBuf = [crate::SYSFS_PATH, "devices"].iter().collect();
+    root_path.join(dev_path)
+}


### PR DESCRIPTION
I didn't like that the unit tests for traversing the tree were in with the scanner module.

This PR extracts some common unit test utilities to a `testing` module and moves some tests to `device`.

I've also changed the `Scanner` to collect paths instead of constructing devices, which was needlessly more complicated.